### PR TITLE
feat: (v1.0.3) ESP32 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+dist/
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ if(ESP_PLATFORM)
     idf_component_register(
         SRCS ${UUID4_SOURCES}
         INCLUDE_DIRS ${UUID4_INCLUDE_DIR}
-        REQUIRES 
     )
 
     # Copy header files to include directory and libraries to lib directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,82 +1,105 @@
-
-cmake_minimum_required(VERSION 3.19)
-
-project(
-    uuid4
-    VERSION 1.0.2
-    LANGUAGES C
-)
-
-include(GNUInstallDirs)
+cmake_minimum_required(VERSION 3.24)
 
 set(UUID4_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/uuid4.c
 )
 
-set(UUID4_HEADERS 
+set(UUID4_INCLUDE_DIR
     ${CMAKE_CURRENT_LIST_DIR}/include
 )
 
-add_library(uuid4-static STATIC ${UUID4_SOURCES})
-add_library(uuid4-shared SHARED ${UUID4_SOURCES})
-
-target_include_directories(uuid4-static PUBLIC
-    $<BUILD_INTERFACE:${UUID4_HEADERS}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-target_include_directories(uuid4-shared PUBLIC
-    $<BUILD_INTERFACE:${UUID4_HEADERS}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-
-# ==============
-# configures the install function
-
-# installs the lib targets (.a and .dylib to /usr/local/lib)
-install(
-    TARGETS uuid4-static uuid4-shared
-    EXPORT uuid4-config
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
-# installs the headers (/usr/local/include/uuid4)
-install(
-    DIRECTORY ${UUID4_HEADERS}/${RPOJECT_NAME}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-# ==============
-
-# ==============
-
-if(NOT DEFINED UUID4_AS_SUBPROJECT)
-    set(UUID4_AS_SUBPROJECT ON)
-
-    if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-        set(UUID4_AS_SUBPROJECT OFF)
-    endif()
-endif()
-
-if(NOT UUID4_AS_SUBPROJECT)
-    export(
-        PACKAGE uuid4
+if(ESP_PLATFORM)
+    # Run special CMake commands for ESP32
+    idf_component_register(
+        SRCS ${UUID4_SOURCES}
+        INCLUDE_DIRS ${UUID4_INCLUDE_DIR}
+        REQUIRES 
     )
 
-    # installs the cmake config file (/usr/local/lib/cmake/uuid4/uuid4-config.cmake), which is used by find_package
+    # Copy header files to include directory and libraries to lib directory
+    add_custom_command(
+        TARGET ${COMPONENT_LIB}
+        POST_BUILD
+        COMMAND
+        ${CMAKE_COMMAND} -E copy_directory ${UUID4_INCLUDE_DIR}
+        ${CMAKE_SOURCE_DIR}/include
+        COMMAND
+        ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${COMPONENT_LIB}>
+        ${CMAKE_SOURCE_DIR}/lib/lib${COMPONENT_NAME}.a
+        COMMENT "Copying built archive file and header to lib directory..."
+    )
+endif()
+
+project(
+    uuid4
+    VERSION 1.0.3
+    LANGUAGES C
+)
+
+if(NOT ESP_PLATFORM)
+    include(GNUInstallDirs)
+
+    add_library(uuid4-static STATIC ${UUID4_SOURCES})
+    add_library(uuid4-shared SHARED ${UUID4_SOURCES})
+
+    target_include_directories(uuid4-static PUBLIC
+        $<BUILD_INTERFACE:${UUID4_HEADERS}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+    target_include_directories(uuid4-shared PUBLIC
+        $<BUILD_INTERFACE:${UUID4_HEADERS}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
+    # ==============
+    # configures the install function
+
+    # installs the lib targets (.a and .dylib to /usr/local/lib)
     install(
+        TARGETS uuid4-static uuid4-shared
         EXPORT uuid4-config
-        NAMESPACE uuid4::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/uuid4
-        FILE uuid4-config.cmake
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 
-    export(
-        EXPORT uuid4-config
-        NAMESPACE uuid4::
-        FILE uuid4-config.cmake
+    # installs the headers (/usr/local/include/uuid4)
+    install(
+        DIRECTORY ${UUID4_HEADERS}/${RPOJECT_NAME}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
+
+    # ==============
+
+    # ==============
+    if(NOT DEFINED UUID4_AS_SUBPROJECT)
+        set(UUID4_AS_SUBPROJECT ON)
+
+        if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+            set(UUID4_AS_SUBPROJECT OFF)
+        endif()
+    endif()
+
+    if(NOT UUID4_AS_SUBPROJECT)
+        export(
+            PACKAGE uuid4
+        )
+
+        # installs the cmake config file (/usr/local/lib/cmake/uuid4/uuid4-config.cmake), which is used by find_package
+        install(
+            EXPORT uuid4-config
+            NAMESPACE uuid4::
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/uuid4
+            FILE uuid4-config.cmake
+        )
+
+        export(
+            EXPORT uuid4-config
+            NAMESPACE uuid4::
+            FILE uuid4-config.cmake
+        )
+    endif()
+
+    add_library(uuid4::uuid4-static ALIAS uuid4-static)
+    add_library(uuid4::uuid4-shared ALIAS uuid4-shared)
+
+    # ==============
 endif()
-
-add_library(uuid4::uuid4-static ALIAS uuid4-static)
-add_library(uuid4::uuid4-shared ALIAS uuid4-shared)
-# ==============

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
 version: "1.0.3"
 description: "uuidv4 library"
 url: "https://github.com/atsign-foundation/uuid4"
-license: "BSD-3-Clause"
+license: "MIT"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,4 @@
+version: "1.0.3"
+description: "uuidv4 library"
+url: "https://github.com/atsign-foundation/uuid4"
+license: "BSD-3-Clause"

--- a/src/uuid4.c
+++ b/src/uuid4.c
@@ -13,6 +13,10 @@
 #include <wincrypt.h>
 #endif
 
+#if defined(CONFIG_IDF_TARGET_ESP32)
+#include "esp_random.h"
+#endif
+
 #include "uuid4/uuid4.h"
 
 #if (__STDC_VERSION__ >= 201112L)
@@ -57,6 +61,12 @@ int uuid4_init(void) {
   CryptReleaseContext(hCryptProv, 0);
   if (!res) {
     return UUID4_EFAILURE;
+  }
+
+#elif defined(CONFIG_IDF_TARGET_ESP32)
+  // ESP32 support
+  for (int i = 0; i < sizeof(seed); i++) {
+    seed[i] = esp_random() & 0xFF; // Generate random bytes
   }
 
 #else

--- a/src/uuid4.c
+++ b/src/uuid4.c
@@ -64,9 +64,8 @@ int uuid4_init(void) {
   }
 
 #elif defined(CONFIG_IDF_TARGET_ESP32)
-  // ESP32 support
-  for (int i = 0; i < sizeof(seed); i++) {
-    seed[i] = esp_random() & 0xFF; // Generate random bytes
+  for (int i = 0; i < 2; i++) {
+    seed[i] = ((uint64_t)esp_random() << 32) | esp_random(); // Generate random 64-bit values
   }
 
 #else
@@ -74,7 +73,6 @@ int uuid4_init(void) {
 #endif
   return UUID4_ESUCCESS;
 }
-
 
 void uuid4_generate(char *dst) {
   static const char *template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";


### PR DESCRIPTION
**- What I did**
- Updated uuid4 to `v1.0.3` in `CMakeLists.txt`
- Added ESP32 support using preprocessor functions in `uuid4.c`
- Added ESP32 support in `CMakeLists.txt`

**- How to verify it**

Here's proof of UUID4 generation on ESP32

```c
#include <stdio.h>
#include <string.h>
#include <atclient/atclient.h>
#include <atchops/uuid.h>

void app_main(void) {
    printf("Hello, World!\n");

    atchops_uuid_init();

    char my_str[90];
    memset(my_str, 0, sizeof(char) * 90);

    atchops_uuid_generate(my_str, 90);

    printf("UUID: %s\n", my_str);
}
```

![image](https://github.com/user-attachments/assets/c1114125-c2be-428f-8186-5099cf822474)

**- Description for the changelog**
feat: ESP32 support
