### PR TITLE
ci: Add tarball release workflow

### DIFF
--- a/.github/workflows/tarball.yaml
+++ b/.github/workflows/tarball.yaml
@@ -18,7 +18,8 @@ jobs:
         run: |
           mkdir tarball
           tar -cvzf tarball/uuid4-${{ github.ref_name }}.tar.gz example/ \
-            include/ src/ CMakeLists.txt idf_component.yml LICENSE README.md
+            include/ src/ CHANGELOG.md CMakeLists.txt idf_component.yml \
+            LICENSE README.md
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: uuid4-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}

--- a/.github/workflows/tarball.yaml
+++ b/.github/workflows/tarball.yaml
@@ -1,0 +1,75 @@
+name: UUID4_tarball
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions: # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  source_tarball:
+    name: Generate source tarball
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Create tarball
+        run: |
+          mkdir tarball
+          tar -cvzf tarball/uuid4-${{ github.ref_name }}.tar.gz example/ \
+            include/ src/ CMakeLists.txt idf_component.yml LICENSE README.md
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: uuid4-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
+          path: ./tarball/uuid4-${{ github.ref_name }}.tar.gz
+
+  github-release:
+    name: >-
+      Upload artifacts and generate checksums for provenance
+    needs: [source_tarball]
+    runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      contents: write # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write # IMPORTANT: mandatory for sigstore
+      attestations: write
+    steps:
+      - name: Download all the tarballs
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: tarballs/
+      - name: Move packages for signing
+        run: |
+          cd tarballs
+          mv */*.tar.gz .
+          rm -Rf -- */
+      - name: Generate SHA256 checksums
+        working-directory: tarballs
+        run: sha256sum * > checksums.txt
+      - name: Upload artifacts to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload '${{ github.ref_name }}' tarballs/** --repo '${{
+          github.repository }}'
+      - id: hash
+        name: Pass artifact hashes for SLSA provenance
+        working-directory: tarballs
+        run: |
+          echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+      - uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
+        with:
+          subject-path: "tarballs/**"
+
+  provenance:
+    needs: [github-release]
+    permissions:
+      actions: read # Needed for detection of GitHub Actions environment.
+      id-token: write # Needed for provenance signing and ID
+      contents: write # Needed for release uploads
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0 # 5a775b367a56d5bd118a224a811bba288150a563
+    with:
+      base64-subjects: "${{ needs.github-release.outputs.hashes }}"
+      upload-assets: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 .DS_Store
+example/example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,32 @@
-# 1.0.2
+# UUID4 CHANGELOG
+
+## 1.0.4
+
+- Added workflow to build tarball with attestations
+- Fixed example build script after relocation of uuid4.h
+
+## 1.0.3
+
+- CMakeLists.txt now has Espressif support to be added as a component in your
+ESP-IDF projects.
+- Added ESP32 support in uuid.c
+- Added idf_component.yml manifest to soon be uploaded to the Espressif
+component registry.
+
+## 1.0.2
 
 - Established this CHANGELOG
 - LICENSE updated to reflect fork
 - README linting and note on fork
 - Copy boilerplate from archetype
 
-# 1.0.1
+## 1.0.1
 
 - Support for OpenBSD and NetBSD
 - Thread Safety for C11+ Compilers
 - Refactored uuid4.h to include/uuid/ directory
 - CMake subdirectory AND installation compatability
 
-# 1.0.0
+## 1.0.0
 
 - Initial fork from [rxi/uuid4](https://github.com/rxi/uuid4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 project(
     uuid4
-    VERSION 1.0.3
+    VERSION 1.0.4
     LANGUAGES C
 )
 

--- a/example/build.sh
+++ b/example/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-gcc -Wall -Wextra -o example -I../src/ ../src/uuid4.c example.c
+gcc -Wall -Wextra -o example -I../src/ -I../include/ -I../include/uuid4/ ../src/uuid4.c example.c

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: "uuidv4 library"
 url: "https://github.com/atsign-foundation/uuid4"
 license: "MIT"

--- a/include/uuid4/uuid4.h
+++ b/include/uuid4/uuid4.h
@@ -8,7 +8,7 @@
 #ifndef UUID4_H
 #define UUID4_H
 
-#define UUID4_VERSION "1.0.0"
+#define UUID4_VERSION "1.0.4"
 #define UUID4_LEN 37
 
 enum {


### PR DESCRIPTION
Fixes #4 

@JeremyTubongbanua do you need an MD5 hash? We don't use them elsewhere.

**- What I did**

* Fixed example to build with relocated uuid4.h
* Added example binary to gitignore
* Created a workflow that builds a tarball, generates SHA256 hash, and creates attestations
* Bumped version to 1.0.4 in anticipation of a release that will use the new workflow
* Added v1.0.3 and 1.0.4 changes to CHANGELOG and reformatted to pass markdown lint

**- How I did it**

Workflow based on at_c c_release

**- How to verify it**

Do a release of v1.0.4 once this is merged

**- Description for the changelog**

ci: Add tarball release workflow